### PR TITLE
Envoptions

### DIFF
--- a/minisat/core/Solver.cc
+++ b/minisat/core/Solver.cc
@@ -92,7 +92,8 @@ Solver::Solver() :
 
     // Parameters (user settable):
     //
-    verbosity        (0)
+    reparsed_options (updateOptions())
+  , verbosity        (0)
   , var_decay        (opt_var_decay)
   , clause_decay     (opt_clause_decay)
   , random_var_freq  (opt_random_var_freq)

--- a/minisat/core/Solver.cc
+++ b/minisat/core/Solver.cc
@@ -26,6 +26,8 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 
 #include <math.h>
 
+#include <ctype.h>
+
 #include "minisat/mtl/Alg.h"
 #include "minisat/mtl/Sort.h"
 #include "minisat/utils/System.h"
@@ -56,6 +58,35 @@ static IntOption     opt_min_learnts_lim   (_cat, "min-learnts", "Minimum learnt
 //=================================================================================================
 // Constructor/Destructor:
 
+bool Minisat::updateOptions()
+{
+  if(getenv("MINISAT_RUNTIME_ARGS") == NULL)
+    return false;
+
+  char *args = strdup(getenv("MINISAT_RUNTIME_ARGS")); // make sure it's freed
+  if(!args) return false;
+  char *original_args = args;
+
+  const size_t len = strlen(args);
+
+  char* argv[len+2];
+  int count = 1;
+
+  argv[0] = "minisat";
+  while (isspace(*args)) ++args;
+  while(*args)
+  {
+    argv[count++] = args; // store current argument
+    while (*args && !isspace(*args)) ++args; // skip current token
+    if(!*args) break;
+    *args = (char)0; // separate current token
+    ++args;
+  }
+
+  parseOptions(count, argv, false);
+  free(original_args);
+  return false;
+}
 
 Solver::Solver() :
 

--- a/minisat/core/Solver.h
+++ b/minisat/core/Solver.h
@@ -131,6 +131,7 @@ public:
 
     // Mode of operation:
     //
+    bool      reparsed_options;   // Indicate whether the update parameter method has been used
     int       verbosity;
     double    var_decay;
     double    clause_decay;

--- a/minisat/core/Solver.h
+++ b/minisat/core/Solver.h
@@ -309,6 +309,8 @@ protected:
         return (int)(drand(seed) * size); }
 };
 
+// Method to update cli options from the environment variable MINISAT_RUNTIME_ARGS
+bool updateOptions();
 
 //=================================================================================================
 // Implementation of inline methods:

--- a/minisat/simp/SimpSolver.cc
+++ b/minisat/simp/SimpSolver.cc
@@ -44,7 +44,8 @@ static DoubleOption opt_simp_garbage_frac(_cat, "simp-gc-frac", "The fraction of
 
 
 SimpSolver::SimpSolver() :
-    parsing            (0)
+    simp_reparsed_options(updateOptions())
+  , parsing            (0)
   , grow               (opt_grow)
   , clause_lim         (opt_clause_lim)
   , subsumption_lim    (opt_subsumption_lim)

--- a/minisat/simp/SimpSolver.h
+++ b/minisat/simp/SimpSolver.h
@@ -87,6 +87,7 @@ class SimpSolver : public Solver {
 
     // Mode of operation:
     //
+    bool    simp_reparsed_options; // Indicate whether the update parameter method has been used
     int     parsing;           // Indicate that the solver is currently parsing
     int     grow;              // Allow a variable elimination step to grow by a number of clauses (default to zero).
     int     clause_lim;        // Variables are not eliminated if it produces a resolvent with a length above this limit.


### PR DESCRIPTION
This change allows to modify minisat options via environment parameters. The commandline to be parsed can be specified via the environment variable MINISAT_RUNTIME_ARGS.