### PR TITLE
drat: fix deleting bogus clauses

### DIFF
--- a/minisat/core/Solver.cc
+++ b/minisat/core/Solver.cc
@@ -683,15 +683,31 @@ void Solver::removeSatisfied(vec<CRef>& cs)
         else{
             // Trim clause:
             assert(value(c[0]) == l_Undef && value(c[1]) == l_Undef);
+
+            // record the original clause for the proof
+            add_tmp.clear();
+
             for (int k = 2; k < c.size(); k++)
                 if (value(c[k]) == l_False){
+
+                    if(proofFile && add_tmp.size() == 0)
+                        for(int m = 0; m < c.size(); ) add_tmp.push(c[m++]);
+
                     c[k--] = c[c.size()-1];
                     c.pop();
                 }
+
+            // drop the old clause after adding the new clause
+            if(proofFile && add_tmp.size() > 0)
+            {
+                extendProof(c);
+                extendProof(add_tmp, true);
+            }
             cs[j++] = cs[i];
         }
     }
     cs.shrink(i - j);
+    add_tmp.clear();
 }
 
 

--- a/minisat/core/Solver.h
+++ b/minisat/core/Solver.h
@@ -422,13 +422,13 @@ inline void     Solver::extendProof  (const T& clause, bool remove, Lit drop) {
     if (remove)
         s << "d ";
 
+    assert((drop == lit_Undef || remove == false) && "make sure we only drop in case of remove");
     for (int i = 0; i < clause.size(); i++)
     {
         if(drop == clause[i])
             continue;
         s << (var(clause[i]) + 1) * (-2 * sign(clause[i]) + 1) << " ";
     }
-
     fprintf(proofFile, "%s0\n", s.str().c_str());
 }
 


### PR DESCRIPTION
Currently, the solver only prints DRUP proofs, where deleting clauses
that do not occur is not relevant. Hence, the version until now
produced proofs that contained an unsatisfiable core. However, proof
checker reported spurious clause deletions.

This commit fixes the issue, which is caused by the solver shrinking
clauses in case of falsified literals. This change was not covered
in the proof.

Furthermore, we add an assertion to test whether we are using the
proof API correctly, i.e. only drop literals in case we add a clause
to the proof - which is used when strengthening a clause.